### PR TITLE
refactor(strato): use hal_get_pixel/hal_make_pixel macros instead of raw bit-shifts

### DIFF
--- a/external/PlayfieldEngine/external/StratoHAL/include/strato/strato.h
+++ b/external/PlayfieldEngine/external/StratoHAL/include/strato/strato.h
@@ -508,6 +508,49 @@ hal_get_pixel_b(
 #endif
 }
 
+/*
+ * Get a fixed component slot 1 from a pixel value.
+ */
+static INLINE uint32_t
+hal_get_pixel_c1(
+	hal_pixel_t p)
+{
+	return (p >> 16) & 0xff;
+}
+
+/*
+ * Get a fixed component slot 2 from a pixel value.
+ */
+static INLINE uint32_t
+hal_get_pixel_c2(
+	hal_pixel_t p)
+{
+	return (p >> 8) & 0xff;
+}
+
+/*
+ * Get a fixed component slot 3 from a pixel value.
+ */
+static INLINE uint32_t
+hal_get_pixel_c3(
+	hal_pixel_t p)
+{
+	return p & 0xff;
+}
+
+/*
+ * Compose a pixel value from fixed component slots.
+ */
+static INLINE hal_pixel_t
+hal_make_pixel_fast(
+	uint32_t a,
+	uint32_t c1,
+	uint32_t c2,
+	uint32_t c3)
+{
+	return (((hal_pixel_t)a) << 24) | (((hal_pixel_t)c1) << 16) | (((hal_pixel_t)c2) << 8) | ((hal_pixel_t)c3);
+}
+
 #undef ORDER_RGBA
 #undef ORDER_BGRA
 

--- a/external/PlayfieldEngine/external/StratoHAL/src/drawimage.h
+++ b/external/PlayfieldEngine/external/StratoHAL/src/drawimage.h
@@ -187,23 +187,24 @@ DRAW_IMAGE_GLYPH(
 			dst_a = 1.0f - src_a;
 
 			/* Multiply the alpha value and the source pixel value. */
-			src_r = src_a * (float)((src_pix >> 16) & 0xff);
-			src_g = src_a * (float)((src_pix >> 8) & 0xff);
-			src_b = src_a * (float)(src_pix & 0xff);
+			src_r = src_a * (float)hal_get_pixel_r(src_pix);
+			src_g = src_a * (float)hal_get_pixel_g(src_pix);
+			src_b = src_a * (float)hal_get_pixel_b(src_pix);
 
 			/* Multiply the alpha value and the destination pixel value. */
-			dst_r = dst_a * (float)((dst_pix >> 16) & 0xff);
-			dst_g = dst_a * (float)((dst_pix >> 8) & 0xff);
-			dst_b = dst_a * (float)(dst_pix & 0xff);
+			dst_r = dst_a * (float)hal_get_pixel_r(dst_pix);
+			dst_g = dst_a * (float)hal_get_pixel_g(dst_pix);
+			dst_b = dst_a * (float)hal_get_pixel_b(dst_pix);
 			dst_a_i = hal_get_pixel_a(dst_pix);
 
 			alpha_i = src_a > dst_a ? (uint32_t)(src_a * 255.0f) : dst_a_i;
 
 			/* Store to the destination. */
-			*dst_ptr++ = (alpha_i << 24) |
-				     ((uint32_t)(src_r + dst_r) << 16) |
-				     ((uint32_t)(src_g + dst_g) << 8) |
-				     (uint32_t)(src_b + dst_b);
+			*dst_ptr++ = hal_make_pixel(
+				alpha_i,
+				(uint32_t)(src_r + dst_r),
+				(uint32_t)(src_g + dst_g),
+				(uint32_t)(src_b + dst_b));
 		}
 		src_ptr += src_line_inc;
 		dst_ptr += dst_line_inc;

--- a/external/PlayfieldEngine/external/StratoHAL/src/drawimage.h
+++ b/external/PlayfieldEngine/external/StratoHAL/src/drawimage.h
@@ -176,6 +176,17 @@ DRAW_IMAGE_GLYPH(
 	dst_line_inc = dw - width;
 	a = (float)alpha / 255.0f;
 
+	/*
+	 * Do not use hal_get_pixel_r/g/b() here.
+	 *
+	 * This is a hot blending loop. hal_get_pixel_a() is always a
+	 * simple bit extraction, but hal_get_pixel_r/g/b() may contain
+	 * a branch depending on the active backend pixel order. The
+	 * accessors below intentionally operate on fixed component
+	 * slots, not logical RGB channels, so that the compiler can
+	 * keep this loop branch-free and vectorizable.
+	 */
+
 	for(y = 0; y < height; y++) {
 		for(x = 0; x < width; x++) {
 			/* Get the source and destination pixel values. */
@@ -187,20 +198,20 @@ DRAW_IMAGE_GLYPH(
 			dst_a = 1.0f - src_a;
 
 			/* Multiply the alpha value and the source pixel value. */
-			src_r = src_a * (float)hal_get_pixel_r(src_pix);
-			src_g = src_a * (float)hal_get_pixel_g(src_pix);
-			src_b = src_a * (float)hal_get_pixel_b(src_pix);
+			src_r = src_a * (float)hal_get_pixel_c1(src_pix);
+			src_g = src_a * (float)hal_get_pixel_c2(src_pix);
+			src_b = src_a * (float)hal_get_pixel_c3(src_pix);
 
 			/* Multiply the alpha value and the destination pixel value. */
-			dst_r = dst_a * (float)hal_get_pixel_r(dst_pix);
-			dst_g = dst_a * (float)hal_get_pixel_g(dst_pix);
-			dst_b = dst_a * (float)hal_get_pixel_b(dst_pix);
+			dst_r = dst_a * (float)hal_get_pixel_c1(dst_pix);
+			dst_g = dst_a * (float)hal_get_pixel_c2(dst_pix);
+			dst_b = dst_a * (float)hal_get_pixel_c3(dst_pix);
 			dst_a_i = hal_get_pixel_a(dst_pix);
 
 			alpha_i = src_a > dst_a ? (uint32_t)(src_a * 255.0f) : dst_a_i;
 
 			/* Store to the destination. */
-			*dst_ptr++ = hal_make_pixel(
+			*dst_ptr++ = hal_make_pixel_fast(
 				alpha_i,
 				(uint32_t)(src_r + dst_r),
 				(uint32_t)(src_g + dst_g),
@@ -1122,9 +1133,9 @@ DRAW_IMAGE_3D_DIM(
 			src_b = src_a * 0.5f * (float)hal_get_pixel_b(src_pix);
 
 			/* Multiply the alpha value and the destination pixel value. */
-			dst_r = dst_a * (float)hal_get_pixel_r(dst_pix);
-			dst_g = dst_a * (float)hal_get_pixel_g(dst_pix);
-			dst_b = dst_a * (float)hal_get_pixel_b(dst_pix);
+			dst_r = dst_a * (float)hal_get_pixel_c1(dst_pix);
+			dst_g = dst_a * (float)hal_get_pixel_c2(dst_pix);
+			dst_b = dst_a * (float)hal_get_pixel_c3(dst_pix);
 
 			/* Store to the destination. */
 			dst_pixel[y * dw + x] =

--- a/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
+++ b/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
@@ -862,9 +862,9 @@ draw_glyph_func(
 		font_real_height -= (image_real_y + font_real_height) - image_height;
 
 	/* Draw. */
-	color_r = hal_get_pixel_r(color);
-	color_g = hal_get_pixel_g(color);
-	color_b = hal_get_pixel_b(color);
+	color_r = hal_get_pixel_c1(color);
+	color_g = hal_get_pixel_c2(color);
+	color_b = hal_get_pixel_c3(color);
 	dst_ptr = image + image_real_y * image_width + image_real_x;
 	src_ptr = font + font_real_y * font_width + font_real_x;
 	for (py = font_real_y; py < font_real_y + font_real_height; py++) {

--- a/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
+++ b/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
@@ -878,9 +878,9 @@ draw_glyph_func(
 			src_b = color_b;
 
 			dst_a = hal_get_pixel_a(dst_pix);
-			dst_r = hal_get_pixel_r(dst_pix);
-			dst_g = hal_get_pixel_g(dst_pix);
-			dst_b = hal_get_pixel_b(dst_pix);
+			dst_r = hal_get_pixel_c1(dst_pix);
+			dst_g = hal_get_pixel_c2(dst_pix);
+			dst_b = hal_get_pixel_c3(dst_pix);
 
 			if (src_a == 0) {
 				pix_a = dst_a;
@@ -914,7 +914,7 @@ draw_glyph_func(
 					);
 			}
 
-			*dst_ptr++ = hal_make_pixel(
+			*dst_ptr++ = hal_make_pixel_fast(
 				pix_a, pix_r, pix_g, pix_b);
 		}
 		dst_ptr += image_width - font_real_width;

--- a/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
+++ b/external/PlayfieldEngine/external/StratoHAL/src/glyph.c
@@ -862,9 +862,9 @@ draw_glyph_func(
 		font_real_height -= (image_real_y + font_real_height) - image_height;
 
 	/* Draw. */
-	color_r = (color >> 16) & 0xff;
-	color_g = (color >> 8) & 0xff;
-	color_b = color & 0xff;
+	color_r = hal_get_pixel_r(color);
+	color_g = hal_get_pixel_g(color);
+	color_b = hal_get_pixel_b(color);
 	dst_ptr = image + image_real_y * image_width + image_real_x;
 	src_ptr = font + font_real_y * font_width + font_real_x;
 	for (py = font_real_y; py < font_real_y + font_real_height; py++) {
@@ -877,10 +877,10 @@ draw_glyph_func(
 			src_g = color_g;
 			src_b = color_b;
 
-			dst_a = dst_pix >> 24;
-			dst_r = (dst_pix >> 16) & 0xff;
-			dst_g = (dst_pix >> 8) & 0xff;
-			dst_b = dst_pix & 0xff;
+			dst_a = hal_get_pixel_a(dst_pix);
+			dst_r = hal_get_pixel_r(dst_pix);
+			dst_g = hal_get_pixel_g(dst_pix);
+			dst_b = hal_get_pixel_b(dst_pix);
 
 			if (src_a == 0) {
 				pix_a = dst_a;
@@ -914,11 +914,8 @@ draw_glyph_func(
 					);
 			}
 
-			*dst_ptr++ =
-				((pix_a & 0xff) << 24) |
-				((pix_r & 0xff) << 16) |
-				((pix_g & 0xff) << 8) |
-				(pix_b & 0xff);
+			*dst_ptr++ = hal_make_pixel(
+				pix_a, pix_r, pix_g, pix_b);
 		}
 		dst_ptr += image_width - font_real_width;
 		src_ptr += font_width - font_real_width;


### PR DESCRIPTION
## Summary

Introduce branch-free fixed-component-slot pixel helpers (`hal_get_pixel_c1/c2/c3` + `hal_make_pixel_fast`) and apply them to hot blending loops, replacing raw bit-shifts with semantically named yet vectorizable accessors.

Closes #37

## Background

Per [upstream review](https://github.com/awemorris/suika3/issues/37#issuecomment-4465610053):

- `hal_get_pixel_a()` is always simple bit extraction ✓
- `hal_get_pixel_r/g/b()` and `hal_make_pixel()` may contain branches for pixel-order handling (historically OpenGL vs DirectX backends)
- In hot blending loops, these branches would block compiler SIMD vectorization
- The shifts here operate on fixed component slots, not logical RGB channels

## Changes

### `strato.h`
- Add `hal_get_pixel_c1(p)` — fixed slot 1 extraction (always `(p >> 16) & 0xff`)
- Add `hal_get_pixel_c2(p)` — fixed slot 2 extraction (always `(p >> 8) & 0xff`)
- Add `hal_get_pixel_c3(p)` — fixed slot 3 extraction (always `p & 0xff`)
- Add `hal_make_pixel_fast(a, c1, c2, c3)` — branch-free pixel composition

### `drawimage.h`
- Add comment documenting why `hal_get_pixel_r/g/b()` is intentionally avoided in the hot blending loop
- Replace `hal_get_pixel_r/g/b/make_pixel` → `hal_get_pixel_c1/c2/c3` + `hal_make_pixel_fast`

### `glyph.c`
- Inner blending loop: `hal_get_pixel_r/g/b` → `hal_get_pixel_c1/c2/c3`, `hal_make_pixel` → `hal_make_pixel_fast`
- Keep `hal_get_pixel_r/g/b(color)` for one-time color extraction outside the loop

## Verification

All new helpers produce identical bit operations to the original raw shifts under BGRA format, while remaining branch-free for all pixel order configurations.