### PR TITLE
fix(strato): fix incorrect texture regeneration condition in update_texture_if_needed

### DIFF
--- a/external/PlayfieldEngine/external/StratoHAL/src/glrender.c
+++ b/external/PlayfieldEngine/external/StratoHAL/src/glrender.c
@@ -1643,7 +1643,7 @@ update_texture_if_needed(
 	if (img->context == reinit_count && !is_after_reinit && !img->need_upload)
 		return;
 
-	if (img->context == reinit_count || is_after_reinit || img->texture == NULL) {
+	if (img->context != reinit_count || is_after_reinit || img->texture == NULL) {
 		glGenTextures(1, &id);
 		img->texture = (void *)(intptr_t)(id + 1);
 	} else {


### PR DESCRIPTION
## Summary

Fix an inverted condition in `update_texture_if_needed()` that causes unnecessary texture regeneration.

## The Bug

```c
// Before (bug — generates new texture when context is still valid):
if (img->context == reinit_count || is_after_reinit || img->texture == NULL) {
    glGenTextures(1, &id);
```

The condition `img->context == reinit_count` means "the GL context has **not** been reinitialized since this texture was created". In that case, the texture ID is still valid and there is no need to generate a new one — only the pixel data needs updating.

## The Fix

```c
// After (correct — generates new texture only when GL context has changed):
if (img->context != reinit_count || is_after_reinit || img->texture == NULL) {
    glGenTextures(1, &id);
```

## Logic Flow

1. Early return (line 1650): if context matches AND no reinit AND no upload needed → skip entirely
2. After the guard: if context has changed (`!= reinit_count`) → generate new texture (old one is invalid)
3. Otherwise (`== reinit_count`) → reuse existing texture, just update data via `glTexSubImage2D`

## Test plan

- [ ] Verify textures render correctly after GL context reinitialization
- [ ] Verify textures render correctly during normal frame updates (no reinit)