### PR TITLE
fix(gc): use IS_YOUNG_OBJ macro instead of raw RT_GC_REGION_GRADUATE check

### DIFF
--- a/external/PlayfieldEngine/external/NoctLang/src/core/gc.c
+++ b/external/PlayfieldEngine/external/NoctLang/src/core/gc.c
@@ -880,7 +880,7 @@ rt_gc_young_gc_body(
 			struct rt_array *arr = (struct rt_array *)obj;
 			for (i = 0; i < arr->size; i++) {
 				if (IS_REF_VAL(&arr->table[i]) &&
-				    arr->table[i].val.obj->region == RT_GC_REGION_GRADUATE &&
+				    IS_YOUNG_OBJ(arr->table[i].val.obj) &&
 				    arr->table[i].val.obj->forward != NULL) {
 					arr->table[i].val.obj = arr->table[i].val.obj->forward;
 				}
@@ -890,12 +890,12 @@ rt_gc_young_gc_body(
 			for (i = 0; i < dict->alloc_size; i++) {
 				if (dict->key[i].type != NOCT_VALUE_STRING)
 					continue; /* Removed or empty. */
-				if (dict->key[i].val.obj->region == RT_GC_REGION_GRADUATE &&
+				if (IS_YOUNG_OBJ(dict->key[i].val.obj) &&
 				    dict->key[i].val.obj->forward != NULL) {
 					dict->key[i].val.obj = dict->key[i].val.obj->forward;
 				}
 				if (IS_REF_VAL(&dict->value[i]) &&
-				    dict->value[i].val.obj->region == RT_GC_REGION_GRADUATE &&
+				    IS_YOUNG_OBJ(dict->value[i].val.obj) &&
 				    dict->value[i].val.obj->forward != NULL) {
 					dict->value[i].val.obj = dict->value[i].val.obj->forward;
 				}


### PR DESCRIPTION
## Summary

Replace raw `obj->region == RT_GC_REGION_GRADUATE` comparisons with the `IS_YOUNG_OBJ()` macro in the young GC body's remember-set forward-pointer update loop.

## The Bug

In `rt_gc_young_gc_body()`, the remember-set loop updates stale references via forwarding pointers. The original code only checks for `RT_GC_REGION_GRADUATE`:

```c
// Before:
arr->table[i].val.obj->region == RT_GC_REGION_GRADUATE
dict->key[i].val.obj->region == RT_GC_REGION_GRADUATE
dict->value[i].val.obj->region == RT_GC_REGION_GRADUATE
```

However, during a young GC, **both** NURSERY and GRADUATE objects may be moved (and thus have forwarding pointers set). The macro `IS_YOUNG_OBJ` (defined as `(o)->region < RT_GC_REGION_TENURE`) correctly covers both regions.

## The Fix

```c
// After:
IS_YOUNG_OBJ(arr->table[i].val.obj)
IS_YOUNG_OBJ(dict->key[i].val.obj)
IS_YOUNG_OBJ(dict->value[i].val.obj)
```

3 call sites changed. This also makes the code consistent with the 15+ other uses of `IS_YOUNG_OBJ` throughout the GC implementation.

## Test plan

- [ ] Run a test script that triggers young GC with both nursery and graduate objects
- [ ] Verify no stale references remain after young GC