### PR TITLE
fix: fix missing read of last English tag index in save load, fix is_namebox_visible returning wrong variable

### DIFF
--- a/src/save.c
+++ b/src/save.c
@@ -734,6 +734,10 @@ s3_execute_load_local(
 		if (!s3_move_to_tag_index((int)u))
 			break;
 
+		/* Read the last English tag index. */
+		if (!read_u32(&u))
+			break;
+
 		/* Read the gosub return index. */
 		for (i = 0; i < S3_CALL_STACK_MAX; i++) {
 			if (!read_string(sbuf, sizeof(sbuf)))

--- a/src/stage.c
+++ b/src/stage.c
@@ -3017,7 +3017,7 @@ s3_show_namebox(
 bool
 s3_is_namebox_visible(void)
 {
-	return is_msgbox_visible;
+	return is_namebox_visible;
 }
 
 /*


### PR DESCRIPTION
## Summary

- **save.c**: Add missing `read_u32()` for `s3_get_last_english_tag_index()` in `s3_execute_load_local()`. The save function writes this value but the load function omitted the corresponding read, causing the gosub call-stack to be misaligned.
- **stage.c**: Fix `s3_is_namebox_visible()` returning `is_msgbox_visible` instead of `is_namebox_visible`.